### PR TITLE
Fix missing image size in publisher

### DIFF
--- a/publisher.cpp
+++ b/publisher.cpp
@@ -59,6 +59,7 @@ int main()
         Image image;
         image.frame_index(index++);
         image.format("jpeg");
+        image.size(static_cast<uint32_t>(buffer.size()));
         image.frame().assign(buffer.begin(), buffer.end());
 
         writer->write(&image);


### PR DESCRIPTION
## Summary
- assign JPEG buffer length to `Image::size` when publishing frames

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "int2cdr")*

------
https://chatgpt.com/codex/tasks/task_e_683fffe65648832dabeec7d5970f6f81